### PR TITLE
Changed VLC to Media Player In Options Menu

### DIFF
--- a/gui
+++ b/gui
@@ -140,8 +140,8 @@ ${DIRECTORY}/data/options/vlc-args"
         --field='# of results:':NUM "$(cat "$(echo "$options" | sed -n 3p)")"!10..1000!10 \
         --field='Youtube-dl args:la' "​$(cat "$(echo "$options" | sed -n 4p)")" \
         --field='Videos saved to:':DIR "$(cat "$(echo "$options" | sed -n 5p)")" \
-        --field='VLC command:' "​$(cat "$(echo "$options" | sed -n 6p)")" \
-        --field='VLC args:' "​$(cat "$(echo "$options" | sed -n 7p)")" \
+        --field='Media player command:' "​$(cat "$(echo "$options" | sed -n 6p)")" \
+        --field='Media player args:' "​$(cat "$(echo "$options" | sed -n 7p)")" \
         --button=Done!"${DIRECTORY}/icons/check.png":0)"
       button=$?
       if [ $button == 0 ];then


### PR DESCRIPTION
Changed VLC command and VLC args to Media player command and Media player args in options menu because if people see the name VLC they will think that youtubuddy is only compatible with VLC.